### PR TITLE
Add proxy to getCxVersion()

### DIFF
--- a/CX-SDK-API/pom.xml
+++ b/CX-SDK-API/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>checkmarx-sdk</artifactId>
         <groupId>com.cx.sdk</groupId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
 
     <properties>
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>com.cx.sdk</groupId>
             <artifactId>CX-SDK-Application</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>com.cx.sdk</groupId>
             <artifactId>CX-SDK-Infrastructure</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.modelmapper</groupId>

--- a/CX-SDK-Application-Contracts/pom.xml
+++ b/CX-SDK-Application-Contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>checkmarx-sdk</artifactId>
         <groupId>com.cx.sdk</groupId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
 
     <properties>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.cx.sdk</groupId>
             <artifactId>CX-SDK-Domain</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
     </dependencies>
 

--- a/CX-SDK-Application/pom.xml
+++ b/CX-SDK-Application/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>checkmarx-sdk</artifactId>
         <groupId>com.cx.sdk</groupId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
     
     <properties>
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>com.cx.sdk</groupId>
             <artifactId>CX-SDK-Domain</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>com.cx.sdk</groupId>
             <artifactId>CX-SDK-Application-Contracts</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/CX-SDK-Domain/pom.xml
+++ b/CX-SDK-Domain/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>checkmarx-sdk</artifactId>
         <groupId>com.cx.sdk</groupId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
 
     <properties>

--- a/CX-SDK-Infrastructure/pom.xml
+++ b/CX-SDK-Infrastructure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>checkmarx-sdk</artifactId>
         <groupId>com.cx.sdk</groupId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
 
     <properties>
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>com.cx.sdk</groupId>
             <artifactId>CX-SDK-Domain</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>com.cx.sdk</groupId>
             <artifactId>CX-SDK-Application-Contracts</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>com.cx.sdk</groupId>
             <artifactId>CX-SDK-OIDC-login</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
         <dependency>

--- a/CX-SDK-OIDC-login/pom.xml
+++ b/CX-SDK-OIDC-login/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>checkmarx-sdk</artifactId>
         <groupId>com.cx.sdk</groupId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>CX-SDK-OIDC-login</artifactId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.cx.sdk</groupId>
             <artifactId>CX-SDK-Domain</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/CX-SDK-OIDC-login/src/main/java/com/cx/sdk/oidcLogin/restClient/CxServerImpl.java
+++ b/CX-SDK-OIDC-login/src/main/java/com/cx/sdk/oidcLogin/restClient/CxServerImpl.java
@@ -114,7 +114,17 @@ public class CxServerImpl implements ICxServer {
         HttpResponse response;
         HttpUriRequest request;
         String version;
+        HttpClientBuilder builder = HttpClientBuilder.create();
         try {
+
+            if(!isCustomProxySet(proxyParams))
+                builder.useSystemProperties();
+            else
+                setCustomProxy(builder,proxyParams);
+
+            //Add proxy to request
+            client = builder.setDefaultHeaders(headers).build();
+
             request = RequestBuilder
                     .get()
                     .setUri(versionURL)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.cx.sdk</groupId>
     <artifactId>checkmarx-sdk</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
 
     <modules>
         <module>CX-SDK-API</module>


### PR DESCRIPTION
Fixed bug number Bug 236714: [Eclipse] - 9.X plugin version, customer cannot login once has proxy
Tickets:
68117, 76155